### PR TITLE
Episode 9: Twitter app - http server accepting query strings via POST request param and passing it to the main thread via core.async channel

### DIFF
--- a/twitter/project.clj
+++ b/twitter/project.clj
@@ -5,7 +5,10 @@
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [aleph "0.4.6"]
-                 [cheshire "5.8.1"]]
+                 [cheshire "5.8.1"]
+                 [org.clojure/core.async "0.4.490"]
+                 [ring "1.7.1"]
+                 [compojure "1.6.1"]]
   :main ^:skip-aot twitter.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/twitter/src/twitter/api.clj
+++ b/twitter/src/twitter/api.clj
@@ -73,7 +73,7 @@
                                              :content-type :json
                                              :query-params {:grant_type "client_credentials"}}))]
        (if-let [token (:access_token response-body)]
-         {:token token :credentialss credentials}
+         {:token token :credentials credentials}
          (throw (ex-info "Unexpected response - missing access token" {:body response-body})))))))
 
 (s/fdef fetch-retry-auth

--- a/twitter/src/twitter/core.clj
+++ b/twitter/src/twitter/core.clj
@@ -15,7 +15,7 @@
 (defn twitter-loop []
   (loop [auth-state (authenticate)
          seen #{}] ;; `seen` is set of tweet ids
-    (let [[updated-auth-state updated-seen] (processor/process-tweets auth-state seen sleep-time)]
+    (let [[updated-auth-state updated-seen] (processor/process-tweets "#clojure" auth-state seen sleep-time)]
       (recur updated-auth-state updated-seen))))
 
 (defn -main
@@ -29,7 +29,7 @@
 
   (search my-auth-state)
 
-  (def main-future (future (-main)))
+  (def main-future (future (try (-main) (catch Exception e (println "ERROR: " e)))))
 
   (future-cancel main-future)
 

--- a/twitter/src/twitter/core.clj
+++ b/twitter/src/twitter/core.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.edn :as edn]
    [clojure.repl :refer [pst]]
-   [twitter.api :as api]))
+   [twitter.api :as api]
+   [twitter.server :as server]))
 
 (def twitter-creds (edn/read-string (slurp ".creds.edn")))
 (def sleep-time 15000)
@@ -41,6 +42,7 @@
 (defn -main
   "I don't do a whole lot ... yet."
   [& args]
+  (server/start-server)
   (loop [auth-state (authenticate)
          seen #{}] ;; `seen` is set of tweet ids
     (let [[updated-auth-state tweets] (or (search auth-state) [auth-state []])

--- a/twitter/src/twitter/core.clj
+++ b/twitter/src/twitter/core.clj
@@ -56,4 +56,6 @@
 
   (def main-future (future (-main)))
 
+  (future-cancel main-future)
+
   )

--- a/twitter/src/twitter/core.clj
+++ b/twitter/src/twitter/core.clj
@@ -31,6 +31,7 @@
 
   (def main-future (future (-main)))
 
-  (future-cancel
+  (future-cancel main-future)
 
-   main-future))
+
+  )

--- a/twitter/src/twitter/core.clj
+++ b/twitter/src/twitter/core.clj
@@ -1,55 +1,28 @@
 (ns twitter.core
   (:require
    [clojure.edn :as edn]
-   [clojure.repl :refer [pst]]
    [twitter.api :as api]
+   [twitter.processor :as processor]
    [twitter.server :as server]))
 
-(def twitter-creds (edn/read-string (slurp ".creds.edn")))
+;; TODO: externalize configuration completely
 (def sleep-time 15000)
+(def twitter-creds (edn/read-string (slurp ".creds.edn")))
 
 (defn- authenticate []
   (api/authenticate twitter-creds))
 
-(defn- search [auth-state]
-  (try 
-    (api/search auth-state "#clojure")
-    (catch Exception e
-      ;; TODO: it might be too late to catch data here
-      ;; since we would need reponse boy if non-ok HTTP status is thrown
-      ;; => if we don't do that in `twitter.api` ns then http client details will leak
-      (pst e))))
-
-(defn format-tweets [tweets]
-  (let [format-tweet (fn format-tweet [tweet]
-                       (format " * %s tweeted: '%s'"
-                               (:user/name tweet)
-                               (some-> tweet :tweet/text (clojure.string/replace "\n" " "))))]
-    (if (empty? tweets)
-      []
-      (mapv format-tweet tweets))))
-
-;; TODO: use proper cache evicting old entries to prevent out of memory
-;; Check https://github.com/clojure/core.cache/wiki/Using
-(defn remove-already-seen-tweets [seen tweets]
-  (let [new-tweets (remove (fn [{:tweet/keys [id]}]
-                             (contains? seen id))
-                           tweets)]
-    ;; (prn "DEBUG:: " tweets)
-    ;; (prn "DEBUG:: " new-tweets)
-    [new-tweets (apply conj seen (map :tweet/id new-tweets))]))
+(defn twitter-loop []
+  (loop [auth-state (authenticate)
+         seen #{}] ;; `seen` is set of tweet ids
+    (let [[updated-auth-state updated-seen] (processor/process-tweets auth-state seen sleep-time)]
+      (recur updated-auth-state updated-seen))))
 
 (defn -main
   "I don't do a whole lot ... yet."
   [& args]
   (server/start-server)
-  (loop [auth-state (authenticate)
-         seen #{}] ;; `seen` is set of tweet ids
-    (let [[updated-auth-state tweets] (or (search auth-state) [auth-state []])
-         [new-tweets updated-seen] (remove-already-seen-tweets seen tweets)]
-    (run! println (format-tweets new-tweets))
-    (Thread/sleep sleep-time)
-    (recur updated-auth-state updated-seen))))
+  (twitter-loop))
 
 (comment
   (def my-auth-state (api/authenticate twitter-creds))
@@ -58,6 +31,6 @@
 
   (def main-future (future (-main)))
 
-  (future-cancel main-future)
+  (future-cancel
 
-  )
+   main-future))

--- a/twitter/src/twitter/core.clj
+++ b/twitter/src/twitter/core.clj
@@ -1,28 +1,47 @@
 (ns twitter.core
+  "Main namespace starting an infinite loop waiting for twitter queries
+  and searching for matching tweets in pre-defined intervals."
   (:require
+   [clojure.core.async :as async]
    [clojure.edn :as edn]
    [twitter.api :as api]
    [twitter.processor :as processor]
    [twitter.server :as server]))
 
 ;; TODO: externalize configuration completely
-(def sleep-time 15000)
+(def tweets-fetch-interval 15000)
 (def twitter-creds (edn/read-string (slurp ".creds.edn")))
 
 (defn- authenticate []
   (api/authenticate twitter-creds))
 
-(defn twitter-loop []
-  (loop [auth-state (authenticate)
+(defn twitter-loop [query-channel]
+  ;; start with the default search query:
+  (async/>!! query-channel "#clojure")
+
+  (loop [old-query nil
+         auth-state (authenticate)
          seen #{}] ;; `seen` is set of tweet ids
-    (let [[updated-auth-state updated-seen] (processor/process-tweets "#clojure" auth-state seen sleep-time)]
-      (recur updated-auth-state updated-seen))))
+    (let [[new-query port] (async/alts!! [query-channel
+                                          (async/timeout tweets-fetch-interval)])
+          query (or new-query old-query)
+          _ (when new-query (println " Got new query: " new-query))
+          [updated-auth-state updated-seen]
+          ;; if timeout happens, keep using the old query
+          ;; otherwise search using the new query got from search-channel
+          (processor/process-tweets query
+                                    auth-state
+                                    ;; tweet cache is emptied if we get a new search query via channel
+                                    (if (= port query-channel) #{} seen))]
+      (recur query updated-auth-state updated-seen))))
 
 (defn -main
-  "I don't do a whole lot ... yet."
+  "Runs the main loop polling for tweets."
   [& args]
-  (server/start-server)
-  (twitter-loop))
+  ;; TODO: exception handler?
+  (let [query-channel (async/chan 10)]
+    (server/start-server query-channel)
+    (twitter-loop query-channel)))
 
 (comment
   (def my-auth-state (api/authenticate twitter-creds))

--- a/twitter/src/twitter/processor.clj
+++ b/twitter/src/twitter/processor.clj
@@ -37,14 +37,12 @@
     [new-tweets (apply conj seen (map :tweet/id new-tweets))]))
 
 (defn process-tweets
-  "Gets new tweets, prints them, sleeps for `sleep-time`
-  and returns a tuple [updated-auth-state updated-seen].
+  "Gets new tweets, prints them, and returns a tuple [updated-auth-state updated-seen].
   This is a single step in a never-ending loop."
-  [query auth-state seen sleep-time]
+  [query auth-state seen]
   (let [[updated-auth-state tweets] (or (search auth-state query)
                                         [auth-state []])
         [new-tweets updated-seen] (remove-already-seen-tweets seen tweets)]
     (run! println (format-tweets new-tweets))
-    (Thread/sleep sleep-time)
     [updated-auth-state updated-seen]))
 

--- a/twitter/src/twitter/processor.clj
+++ b/twitter/src/twitter/processor.clj
@@ -41,7 +41,8 @@
   and returns a tuple [updated-auth-state updated-seen].
   This is a single step in a never-ending loop."
   [auth-state seen sleep-time]
-  (let [[updated-auth-state tweets] (or (search auth-state) [auth-state []])
+  (let [[updated-auth-state tweets] (or (search auth-state)
+                                        [auth-state []])
         [new-tweets updated-seen] (remove-already-seen-tweets seen tweets)]
     (run! println (format-tweets new-tweets))
     (Thread/sleep sleep-time)

--- a/twitter/src/twitter/processor.clj
+++ b/twitter/src/twitter/processor.clj
@@ -8,9 +8,9 @@
    [clojure.repl :refer [pst]]
    [twitter.api :as api]))
 
-(defn- search [auth-state]
+(defn- search [auth-state query]
   (try
-    (api/search auth-state "#clojure")
+    (api/search auth-state query)
     (catch Exception e
       ;; TODO: it might be too late to catch data here
       ;; since we would need reponse boy if non-ok HTTP status is thrown
@@ -40,8 +40,8 @@
   "Gets new tweets, prints them, sleeps for `sleep-time`
   and returns a tuple [updated-auth-state updated-seen].
   This is a single step in a never-ending loop."
-  [auth-state seen sleep-time]
-  (let [[updated-auth-state tweets] (or (search auth-state)
+  [query auth-state seen sleep-time]
+  (let [[updated-auth-state tweets] (or (search auth-state query)
                                         [auth-state []])
         [new-tweets updated-seen] (remove-already-seen-tweets seen tweets)]
     (run! println (format-tweets new-tweets))

--- a/twitter/src/twitter/processor.clj
+++ b/twitter/src/twitter/processor.clj
@@ -1,0 +1,49 @@
+(ns twitter.processor
+  "Processor is a terrible name but this namespace capture the never-ending process of
+  fetching tweets (via `twitter.api`) and printing them into console.
+  The whole process then sleeps and is repeated over and over again,
+  possibly with an updated search string."
+  (:require
+
+   [clojure.repl :refer [pst]]
+   [twitter.api :as api]))
+
+(defn- search [auth-state]
+  (try
+    (api/search auth-state "#clojure")
+    (catch Exception e
+      ;; TODO: it might be too late to catch data here
+      ;; since we would need reponse boy if non-ok HTTP status is thrown
+      ;; => if we don't do that in `twitter.api` ns then http client details will leak
+      (pst e))))
+
+(defn format-tweets [tweets]
+  (let [format-tweet (fn format-tweet [tweet]
+                       (format " * %s tweeted: '%s'"
+                               (:user/name tweet)
+                               (some-> tweet :tweet/text (clojure.string/replace "\n" " "))))]
+    (if (empty? tweets)
+      []
+      (mapv format-tweet tweets))))
+
+;; TODO: use proper cache (evicting old entries to prevent out of memory)
+;; Check https://github.com/clojure/core.cache/wiki/Using
+(defn remove-already-seen-tweets [seen tweets]
+  (let [new-tweets (remove (fn [{:tweet/keys [id]}]
+                             (contains? seen id))
+                           tweets)]
+    ;; (prn "DEBUG:: " tweets)
+    ;; (prn "DEBUG:: " new-tweets)
+    [new-tweets (apply conj seen (map :tweet/id new-tweets))]))
+
+(defn process-tweets
+  "Gets new tweets, prints them, sleeps for `sleep-time`
+  and returns a tuple [updated-auth-state updated-seen].
+  This is a single step in a never-ending loop."
+  [auth-state seen sleep-time]
+  (let [[updated-auth-state tweets] (or (search auth-state) [auth-state []])
+        [new-tweets updated-seen] (remove-already-seen-tweets seen tweets)]
+    (run! println (format-tweets new-tweets))
+    (Thread/sleep sleep-time)
+    [updated-auth-state updated-seen]))
+

--- a/twitter/src/twitter/server.clj
+++ b/twitter/src/twitter/server.clj
@@ -4,10 +4,20 @@
   Can be started stopped via given methods.
   The HTTP server instance is tracked internally and not exposed to the client."
   (:require [aleph.http :as http]
-            [compojure.core :refer [defroutes GET POST]]))
+            [compojure.core :refer [defroutes GET POST]]
+            [ring.middleware.params :as rparams]))
 
-(defroutes app
-  (GET "/" [] "Search string updated to: <b>TODO</b>"))
+(defn handle-search-query-update [query]
+  (format "Search string updated to: <b>%s</b>" query))
+
+;; Check https://github.com/weavejester/compojure/wiki/Destructuring-Syntax
+;; and https://github.com/ring-clojure/ring/wiki/Parameters
+(defroutes app-routes
+  (GET "/" [q] (handle-search-query-update q)))
+
+(def app
+  (-> app-routes
+      rparams/wrap-params))
 
 (defonce ^:private server (atom nil))
 
@@ -20,7 +30,7 @@
   (stop-server)
   (println "Starting the server...")
   (reset! server
-          (http/start-server app
+          (http/start-server #'app
                              ;; TODO: port should be configurable
                              {:port 8081}))
   (println "Server started.")

--- a/twitter/src/twitter/server.clj
+++ b/twitter/src/twitter/server.clj
@@ -1,0 +1,33 @@
+(ns twitter.server
+  "HTTP server running on port 8081 and listening for search queries on `/search` endpoint (POST)
+  and updating the main thread to take the new query into account."
+  (:require [aleph.http :as http]
+            [compojure.core :refer [defroutes GET POST]]))
+
+(defroutes app
+  (GET "/" [] "Search string updated to: <b>TODO</b>"))
+
+(defonce ^:private server (atom nil))
+
+(defn stop-server [server]
+  (when server
+    (println "Stopping the server...")
+    (.close server)))
+
+(defn start-server []
+  (stop-server @server)
+  (println "Starting the server...")
+  (reset! server
+          (http/start-server app
+                             {:port 8081}))
+  (println "Server started."))
+
+
+
+(comment
+
+  (def my-server (start-server))
+
+
+
+  )

--- a/twitter/src/twitter/server.clj
+++ b/twitter/src/twitter/server.clj
@@ -1,6 +1,8 @@
 (ns twitter.server
-  "HTTP server running on port 8081 and listening for search queries on `/search` endpoint (POST)
-  and updating the main thread to take the new query into account."
+  "Stateful HTTP server running on port 8081 and listening for search queries on `/search` endpoint (POST)
+  and updating the main thread to take the new query into account.
+  Can be started stopped via given methods.
+  The HTTP server instance is tracked internally and not exposed to the client."
   (:require [aleph.http :as http]
             [compojure.core :refer [defroutes GET POST]]))
 
@@ -9,25 +11,27 @@
 
 (defonce ^:private server (atom nil))
 
-(defn stop-server [server]
-  (when server
+(defn stop-server []
+  (when @server
     (println "Stopping the server...")
-    (.close server)))
+    (.close @server)))
 
 (defn start-server []
-  (stop-server @server)
+  (stop-server)
   (println "Starting the server...")
   (reset! server
           (http/start-server app
+                             ;; TODO: port should be configurable
                              {:port 8081}))
-  (println "Server started."))
+  (println "Server started.")
+  )
 
 
 
 (comment
 
-  (def my-server (start-server))
+  (start-server)
 
-
+  (stop-server)
 
   )

--- a/twitter/test/twitter/core_test.clj
+++ b/twitter/test/twitter/core_test.clj
@@ -2,29 +2,3 @@
   (:require [clojure.test :refer [deftest is testing]]
             [twitter.core :as c]))
 
-(deftest format-tweets
-  (testing "no tweets"
-    (is (= []
-           (c/format-tweets []))))
-  (testing "Tweets are properly formatted"
-    (is (= [" * Juraj tweeted: 'Check out Clojure - it's cool!'"
-            " * Joseph tweeted: 'React is cool too!'"]
-           (c/format-tweets [{:user/name "Juraj" :tweet/text "Check out Clojure - it's cool!"}
-                             {:user/name "Joseph" :tweet/text "React is cool too!"}
-                             ]))))
-  (testing "Newline is replaced with space"
-    (is (= [" * Juraj tweeted: 'First tweet line. Second tweet line'"]
-           (c/format-tweets [{:user/name "Juraj"
-                              :tweet/text "First tweet line.\nSecond tweet line"}])))))
-
-(deftest remove-already-seen-tweets
-  (let [tweets [{:tweet/id "123" :tweet/text "OLDEST tweet" :user/name "Juraj"}
-                {:tweet/id "456" :tweet/text "OLD tweet" :user/name "Joseph"}
-                {:tweet/id "789" :tweet/text "NEW tweet" :user/name "Adam"}]]
-    (testing "All tweets are returned new when the cache is empty"
-      (is (= [tweets #{"123" "456" "789"}]
-             (c/remove-already-seen-tweets #{} tweets))))
-    (testing "Only new tweets are returned"
-      (is (= [(drop 2 tweets) #{"123" "456" "789"}]
-             (c/remove-already-seen-tweets #{"123" "456"} tweets)))))
-  )

--- a/twitter/test/twitter/processor_test.clj
+++ b/twitter/test/twitter/processor_test.clj
@@ -1,0 +1,30 @@
+(ns twitter.processor-test
+  (:require [twitter.processor :as p]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest format-tweets
+  (testing "no tweets"
+    (is (= []
+           (p/format-tweets []))))
+  (testing "Tweets are properly formatted"
+    (is (= [" * Juraj tweeted: 'Check out Clojure - it's cool!'"
+            " * Joseph tweeted: 'React is cool too!'"]
+           (p/format-tweets [{:user/name "Juraj" :tweet/text "Check out Clojure - it's cool!"}
+                             {:user/name "Joseph" :tweet/text "React is cool too!"}
+                             ]))))
+  (testing "Newline is replaced with space"
+    (is (= [" * Juraj tweeted: 'First tweet line. Second tweet line'"]
+           (p/format-tweets [{:user/name "Juraj"
+                              :tweet/text "First tweet line.\nSecond tweet line"}])))))
+
+(deftest remove-already-seen-tweets
+  (let [tweets [{:tweet/id "123" :tweet/text "OLDEST tweet" :user/name "Juraj"}
+                {:tweet/id "456" :tweet/text "OLD tweet" :user/name "Joseph"}
+                {:tweet/id "789" :tweet/text "NEW tweet" :user/name "Adam"}]]
+    (testing "All tweets are returned new when the cache is empty"
+      (is (= [tweets #{"123" "456" "789"}]
+             (p/remove-already-seen-tweets #{} tweets))))
+    (testing "Only new tweets are returned"
+      (is (= [(drop 2 tweets) #{"123" "456" "789"}]
+             (p/remove-already-seen-tweets #{"123" "456"} tweets)))))
+  )


### PR DESCRIPTION
https://clojuredesign.club/episode/009-channeling-re-search/

The core namespace and http server are now coupled to core.async channels,
but there's also a new `processor` namespace which encapsulates logic for tweet processing
and knows nothing about channels.

Whole code got more complicated than just using a simple atom without any obvious benefit,
but it's a good learning exercise :).