### PR TITLE
Reimplement authentication mechanism by saving auth state in credentials cache.

### DIFF
--- a/twitter/src/twitter/api.clj
+++ b/twitter/src/twitter/api.clj
@@ -3,6 +3,14 @@
   We use standard API which returns tweets only for the past 7 days
   and doesn't guarantee completeness.
 
+  Authentication:
+  --------------
+  Originally, this was implemented as a tuple [updated-auth-state query-result]
+  returned from the `search` function to the client.
+  However, we now maintain a cache of OAuth tokens in `credentials-cache`
+  and thus the client only needs to pass credentials (api key).
+  This simplified the API and clients don't need to maintain authentication state at all.
+
   We use Aleph as http client: https://github.com/ztellman/aleph
   - check https://github.com/dakrone/clj-http for supported request map params.
 
@@ -15,6 +23,14 @@
    [clojure.spec.alpha :as s])
   (:import (clojure.lang ExceptionInfo)))
 
+;; this is a map from credentials to oauth tokens
+(defonce ^:private credentials-cache (atom {}))
+
+(defn- cached-auth-state [creds]
+  (get @credentials-cache creds))
+
+(defn- save-auth-state [{:keys [credentials] :as auth-state}]
+  (swap! credentials-cache assoc credentials auth-state))
 
 (s/def ::credentials (s/keys :req-un [::api-key ::api-secret]))
 (s/def ::auth-state (s/keys ::req-un [::token ::credentials]))
@@ -45,56 +61,64 @@
 
 (defn fetch
   "Fetches data from given api resource (`path`)
-  by using given authentication state and adding extra `request-options`.
+  by using given OAuth token and adding extra `request-options`.
   This is supposed to be used internally - prefer `fetch-retry-auth` over this function."
-  [auth-state path request-options]
+  [auth-token path request-options]
   (handle-errors
    (fn fetch-fn [] 
      (-> (http/get (api-url path)
                    (merge 
-                    {:oauth-token (:token auth-state)
+                    {:oauth-token auth-token
                      :as :json}
                     request-options)) deref
          response-body))))
 
-(s/fdef authenticate
+(defn- make-auth-state [token creds]
+  {:token token :credentials creds})
+
+(s/fdef authenticate!
   :args (s/cat :credentials ::credentials)
   :ret ::auth-state)
-(defn authenticate
+(defn- authenticate!
   "Authenticates using consumer's api key and secret
-  and returns authentication auth-state (token).
+  and returns authentication auth-state containing OAuth token.
+  Saves new auth-state into authentication cache to be reused and re-authenticated only when necessary.
+  See `save-auth-state`.
   See https://developer.twitter.com/en/docs/basics/authentication/api-reference/token.html"
   [credentials]
-  (handle-errors
-   (fn auth-fn []
-     (let [response-body (response-body @(http/post (str twitter-api-root-url "/oauth2/token")
-                                            {:basic-auth [(:api-key credentials) (:api-secret credentials)]
-                                             :as :json
-                                             :content-type :json
-                                             :query-params {:grant_type "client_credentials"}}))]
-       (if-let [token (:access_token response-body)]
-         {:token token :credentials credentials}
-         (throw (ex-info "Unexpected response - missing access token" {:body response-body})))))))
+  (let [new-auth-state
+        (handle-errors
+         (fn auth-fn []
+           (let [response-body (response-body @(http/post (str twitter-api-root-url "/oauth2/token")
+                                                          {:basic-auth [(:api-key credentials) (:api-secret credentials)]
+                                                           :as :json
+                                                           :content-type :json
+                                                           :query-params {:grant_type "client_credentials"}}))]
+             (if-let [token (:access_token response-body)]
+               (make-auth-state token credentials)
+               (throw (ex-info "Unexpected response - missing access token" {:body response-body}))))))]
+    (save-auth-state new-auth-state)))
 
 (s/fdef fetch-retry-auth
   :args (s/cat :auth-state ::auth-state
                :path string?
                :request-options map?)
-  :ret (s/tuple ::auth-state ::response-data))
+  :ret ::response-data)
 (defn fetch-retry-auth
   "Similar to `fetch` but retries on authentication errors.
   Gives up after a single retry since that's very likely another issue with the call
   or permenant authentication error."
   ;; I guess it wasn't mentioned in the podcast but `:credentials` are necessary
   ;; to be able to re-authenticate at any point
-  [{:keys [credentials] :as auth-state} path request-options]
-  (try
-    [auth-state (fetch auth-state path request-options)]
-    (catch ExceptionInfo e
-      (println "Got Exception" e)
-      (println "=> Reauthenticating")
-      (let [new-auth-state (authenticate credentials)]
-        [new-auth-state (fetch new-auth-state path request-options)]))))
+  [creds path request-options]
+  (let [{:keys [token credentials]} (or (cached-auth-state creds) (authenticate! creds))]
+    (try
+      (fetch token path request-options)
+      (catch ExceptionInfo e
+        (println "Got Exception" e)
+        (println "=> Reauthenticating")
+        (let [{:keys [token]} (authenticate! credentials)]
+          (fetch token path request-options))))))
 
 (s/def :twitter/tweet (s/keys :req [:tweet/id :tweet/text :user/name]))
 
@@ -111,23 +135,23 @@
       (map raw->tweet)))
 
 (s/fdef search
-  :args (s/cat :handle map?
+  :args (s/cat :creds ::credentials
                :query string?)
-  :ret (s/tuple map? (s/coll-of :twitter/tweet)))
+  :ret (s/coll-of :twitter/tweet))
 (defn search
-  "Finds all matching tweets for given query.
-  Returns a tuple [updated-auth-state tweets].
+  "Finds all matching tweets for given query and returns them.
+  Reauthenticates automatically if an OAuth token is expired.
   See https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets.html"
-  [auth-state query]
-  (let [[updated-auth-state raw-tweets] (fetch-retry-auth auth-state "/search/tweets.json" {:query-params {:q  query}})
+  [creds query]
+  (let [raw-tweets (fetch-retry-auth creds "/search/tweets.json" {:query-params {:q  query}})
         tweets (raw->tweets raw-tweets)]
-    [updated-auth-state tweets]))
+    tweets))
 
 (comment
 
   (def twitter-creds (edn/read-string (slurp ".creds.edn")))
 
-  (def my-auth-state (authenticate twitter-creds))
+  (def my-auth-state (authenticate! twitter-creds))
 
   (time (search my-auth-state "clojure"))
 

--- a/twitter/src/twitter/core.clj
+++ b/twitter/src/twitter/core.clj
@@ -5,7 +5,8 @@
    [clojure.core.async :as async]
    [com.stuartsierra.component :as component]
    [twitter.fetcher :as fetcher]
-   [twitter.server :as server]))
+   [twitter.server :as server]
+   [twitter.api :as api]))
 
 (defn new-system
   []
@@ -34,9 +35,8 @@
 ;;     (System/exit 0)))
 
 (comment
-  (def my-auth-state (api/authenticate twitter-creds))
 
-  (search my-auth-state)
+  (api/search fetcher/twitter-creds "#clojure")
 
   (def main-system (-main))
 

--- a/twitter/src/twitter/fetcher.clj
+++ b/twitter/src/twitter/fetcher.clj
@@ -6,35 +6,29 @@
    [clojure.edn :as edn]
    [clojure.core.async :as async]
    [com.stuartsierra.component :as component]
-   [twitter.api :as api]
    [twitter.processor :as processor]))
 
 ;; TODO: externalize configuration completely
 (def tweets-fetch-interval 15000)
 (def twitter-creds (edn/read-string (slurp ".creds.edn")))
 
-(defn- authenticate []
-  (api/authenticate twitter-creds))
-
 (defn twitter-loop [query-channel]
   ;; start with the default search query:
   (async/>!! query-channel "#clojure")
   ;; keep processing until we get another query or timeout happens
   (loop [old-query nil
-         auth-state (authenticate)
          seen #{}] ;; `seen` is set of tweet ids
-    (let [[new-query port] (async/alts!! [query-channel
-                                          (async/timeout tweets-fetch-interval)])
-          query (or new-query old-query)
-          _ (when new-query (println " Got new query: " new-query))
-          [updated-auth-state updated-seen]
+    (let [[new-query port] (async/alts!! [query-channel (async/timeout tweets-fetch-interval)])
           ;; if timeout happens, keep using the old query
           ;; otherwise search using the new query got from search-channel
-          (processor/process-tweets query
-                                    auth-state
-                                    ;; tweet cache is emptied if we get a new search query via channel
-                                    (if (= port query-channel) #{} seen))]
-      (recur query updated-auth-state updated-seen))))
+          query (or new-query old-query)
+          _ (when new-query (println " Got new query: " new-query))
+          seen-tweets (processor/process-tweets
+                       query
+                       twitter-creds
+                       ;; tweet cache is emptied if we get a new search query via channel
+                       (if (= port query-channel) #{} seen))]
+      (recur query seen-tweets))))
 
 (defrecord Fetcher [loop-future query-channel]
   component/Lifecycle

--- a/twitter/src/twitter/processor.clj
+++ b/twitter/src/twitter/processor.clj
@@ -8,9 +8,9 @@
    [clojure.repl :refer [pst]]
    [twitter.api :as api]))
 
-(defn- search [auth-state query]
+(defn- search [creds query]
   (try
-    (api/search auth-state query)
+    (api/search creds query)
     (catch Exception e
       ;; TODO: it might be too late to catch data here
       ;; since we would need reponse boy if non-ok HTTP status is thrown
@@ -37,12 +37,11 @@
     [new-tweets (apply conj seen (map :tweet/id new-tweets))]))
 
 (defn process-tweets
-  "Gets new tweets, prints them, and returns a tuple [updated-auth-state updated-seen].
+  "Gets new tweets, prints them, and returns `seen` updated with the new tweets.
   This is a single step in a never-ending loop."
-  [query auth-state seen]
-  (let [[updated-auth-state tweets] (or (search auth-state query)
-                                        [auth-state []])
-        [new-tweets updated-seen] (remove-already-seen-tweets seen tweets)]
+  [query creds seen]
+  (let [tweets (or (search creds query)[])
+        [new-tweets updated-seen-tweets] (remove-already-seen-tweets seen tweets)]
     (run! println (format-tweets new-tweets))
-    [updated-auth-state updated-seen]))
+    updated-seen-tweets))
 


### PR DESCRIPTION
This simplified the API and clients now don't need to maintain auth state at all.
They just pass credentials and the api will request OAuth token automatically
and re-authenticate when necessary.